### PR TITLE
Add link to `restic-automatic-backup-scheduler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Awesome [Restic](https://restic.net) related projects.
 * [restic2influx](https://github.com/hn/restic2influx) - Parse Restic status output and feed summary to influx db
 * [restic-wrapper](https://github.com/peterrus/restic-wrapper) - Simple bash wrapper to source .env configuration files for Restic (and optionally rclone).
 * [Ludusavi Restic Playnite Plugin](https://github.com/sharkusmanch/playnite-ludusavi-restic) - Plugin for [Playnite](https://playnite.link) that allows for creating point-in-time snapshots of game save data.
-
+* [restic-automatic-backup-scheduler](https://github.com/erikw/restic-automatic-backup-scheduler) - Automatic restic backup using Backblaze B2 storage and either Linux systemd timers, macOS LaunchAgent, Windows ScheduledTask or simply cron
 
 ## Documentation
 


### PR DESCRIPTION
I have never used this tool but came across it when looking for a Restic wrapper and thought that it might belong here. 🙂