### PR TITLE
Added resticterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Awesome [Restic](https://restic.net) related projects.
 * [Restic Browser](https://github.com/emuell/restic-browser) - A clientside GUI (Win/Linux/Mac) to browser your Restic repository snapshots
 * [NPBackup](https://github.com/netinvent/npbackup) - A GUI & CLI backup program that adds Prometheus support, VSS fallback, cloud files excludes, etc... For Windows and Linux, and arm based NAS devices.
 * [Restic Backup GX](https://gitlab.com/stormking/resticguigx/-/blob/master/README.md) - Easy to use desktop GUI with profiles
-
+* [resticterm](https://github.com/GPh83/resticterm) - resticterm is a multi-platform UI for restic backup software. It can be used alone for backup tools or with restic command line for manage repository.
 
 ## Wrappers
 


### PR DESCRIPTION
_resticterm_ is a multi-platform UI for _restic_ backup software. (https://restic.net/).
It can be used alone for backup tools or with restic command line for manage repository.