### PR TITLE
Add restic-drill to Other

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -291,6 +291,11 @@ intro = "Awesome [Restic](https://restic.net) related projects."
     url = "https://github.com/ngosang/restic-exporter"
     description = "A Prometheus exporter for Restic backup metrics"
 
+  [[sections.items]]
+    name = "restic-drill"
+    url = "https://github.com/iacosta3994/restic-drill"
+    description = "Automated restore-drills: restores a rotating file from each repository and sha256-compares the bytes against the live file, proving backups restore correct data. Runs as a weekly systemd timer and alerts on failure."
+
 [[sections]]
   name = "Commercial"
 


### PR DESCRIPTION
Adds [restic-drill](https://github.com/iacosta3994/restic-drill) to the **Other** section of `data.toml` (README is auto-generated, so I only edited the data file).

restic-drill runs automated **restore-drills**: it restores a rotating file from each configured repository and sha256-compares the bytes against the live file, proving the backup actually restores correct data — a guarantee `restic check --read-data` doesn't give (that verifies stored-pack integrity, not that a restore reconstructs the right bytes). Multi-repo (local + sftp offsite), runs as a weekly systemd timer, alerts on failure. MIT, Rust.

Placed at the end of the Other section; `data.toml` validated as parseable TOML.