### PR TITLE
Add restic-backup-toolkit

### DIFF
--- a/data.toml
+++ b/data.toml
@@ -229,6 +229,11 @@ intro = "Awesome [Restic](https://restic.net) related projects."
     url = "https://github.com/lminlone/repliqate"
     description = "A modular Docker container/volume backup solution"
 
+  [[sections.items]]
+    name = "restic-backup-toolkit"
+    url = "https://github.com/andersyin/restic-backup-toolkit"
+    description = "3-tier macOS backup: rsync mirror + restic cold backup + SHA256 audit. launchd automation, zero cloud."
+
 [[sections]]
   name = "Documentation"
 


### PR DESCRIPTION
3-tier macOS backup system: rsync mirror + restic cold backup + SHA256 integrity audit. Features:
- Tiered cold backup (T1 work / T2 personal / T3 archive)
- launchd automation (WatchPaths trigger on disk plug-in)
- SHA256 bit-rot detection for single-copy archives
- Zero cloud, zero subscription
- Pure bash, only depends on restic + rsync + shasum

Repository: https://github.com/andersyin/restic-backup-toolkit